### PR TITLE
lua 5.4.8 win-64

### DIFF
--- a/recipe/CMakeLists.txt
+++ b/recipe/CMakeLists.txt
@@ -1,0 +1,68 @@
+# Credit to https://github.com/walterschell/Lua/blob/master/lua-5.3.3/CMakeLists.txt
+# The version is inspired by the above link.
+cmake_minimum_required(VERSION 3.5)
+project(lua C)
+
+include_directories(src)
+set(LUA_LIB_SRCS
+    src/lapi.c
+    src/lcode.c
+    src/lctype.c
+    src/ldebug.c
+    src/ldo.c
+    src/ldump.c
+    src/lfunc.c
+    src/lgc.c
+    src/llex.c
+    src/lmem.c
+    src/lobject.c
+    src/lopcodes.c
+    src/lparser.c
+    src/lstate.c
+    src/lstring.c
+    src/ltable.c
+    src/ltm.c
+    src/lundump.c
+    src/lvm.c
+    src/lzio.c
+    src/lauxlib.c
+    src/lbaselib.c
+    src/lcorolib.c
+    src/ldblib.c
+    src/liolib.c
+    src/lmathlib.c
+    src/loslib.c
+    src/lstrlib.c
+    src/ltablib.c
+    src/lutf8lib.c
+    src/loadlib.c
+    src/linit.c)
+
+add_library(liblua ${LUA_LIB_SRCS})
+set_target_properties(liblua PROPERTIES OUTPUT_NAME "lua")
+if(BUILD_SHARED_LIBS)
+  target_compile_definitions(liblua PRIVATE LUA_BUILD_AS_DLL)
+endif()
+
+add_executable(lua src/lua.c ${LUA_LIB_SRCS})
+target_link_libraries(lua)
+
+add_executable(luac src/luac.c ${LUA_LIB_SRCS})
+target_link_libraries(luac)
+
+install(TARGETS liblua
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin)
+
+install(TARGETS lua luac DESTINATION bin)
+
+set(LUA_PUBLIC_INCLUDES
+    src/lauxlib.h
+    src/lua.h
+    src/lua.hpp
+    src/luaconf.h
+    src/lualib.h)
+
+install(FILES ${LUA_PUBLIC_INCLUDES}
+        DESTINATION include)

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,21 @@
+:: MSVC is preferred.
+set CC=cl.exe
+set CXX=cl.exe
+
+mkdir build
+cd build
+cmake ^
+    -G "Ninja" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DBUILD_SHARED_LIBS=ON ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,28 +5,42 @@ package:
   version: {{ version }}
 
 source:
-  fn: lua-{{ version }}.tar.gz
-  url: https://www.lua.org/ftp/lua-{{ version }}.tar.gz
-  sha256: 4f18ddae154e793e46eeab727c59ef1c0c0c2b744e7b94219710d76f530629ae
-  patches:
-    - 0001-default-compiler.patch
+  - url: https://www.lua.org/ftp/lua-{{ version }}.tar.gz
+    sha256: 4f18ddae154e793e46eeab727c59ef1c0c0c2b744e7b94219710d76f530629ae
+    patches:
+      - 0001-default-compiler.patch
+  - path: CMakeLists.txt
 
 build:
-  skip: true  # [win]
-  number: 0
+  number: 1
+  skip: true  # [not win]
 
 requirements:
   build:
     - {{ compiler('c') }}
-    - patch
-    - make
+    - {{ stdlib('c') }}
+    - patch  # [unix]
+    - make  # [unix]
+    - ninja  # [win]
+    - cmake  # [win]
+  host:
+    - readline  # [unix]
+    - ncurses  # [unix]
+  run:
+    - readline  # [unix]
+    - ncurses  # [unix]
 
 test:
   commands:
-    - test -f $PREFIX/bin/lua
-    - test -f $PREFIX/bin/luac
-    - test -f $PREFIX/lib/liblua.a
-    - test -f $PREFIX/include/lua.h
+    - test -f $PREFIX/bin/lua                       # [unix]
+    - test -f $PREFIX/bin/luac                      # [unix]
+    - test -f $PREFIX/lib/liblua.a                  # [unix]
+    - test -f $PREFIX/include/lua.h                 # [unix]
+    - if not exist %LIBRARY_BIN%\\lua.dll exit 1    # [win]
+    - if not exist %LIBRARY_BIN%\\lua.exe exit 1    # [win]
+    - if not exist %LIBRARY_BIN%\\luac.exe exit 1   # [win]
+    - if not exist %LIBRARY_LIB%\\lua.lib exit 1    # [win]
+    - if not exist %LIBRARY_INC%\\lua.h exit 1      # [win]
     - lua -v
     - lua -e "print(\"Lua path:\" .. package.path)"
     - lua -e "print(\"Lua cpath:\" .. package.cpath)"


### PR DESCRIPTION
## lua 5.4.8 win-64

**Destination channel:** defaults  
**Merge target:** `5.4.8` branch (not `master`)

### Links
- Prerequisite for [burner-redis #1](https://github.com/AnacondaRecipes/burner-redis-feedstock/pull/1) (`lua >=5.4,<5.5` on win-64)

### Changes
- Add CMake Windows build (`bld.bat`, `CMakeLists.txt`) from the 5.5.0 recipe
- `skip: true # [not win]` — only build missing win-64 artifacts
- `build/number: 1` — unix 5.4.8 build 0 already on defaults
- Removed `abs.yaml --skip-existing` (review: did not skip unix rebuilds as intended)

### Test plan
- [ ] CI builds win-64 lua 5.4.8 build 1 only
- [ ] No unix rebuild tasks scheduled